### PR TITLE
Less aggressive call expiry during negotiation

### DIFF
--- a/lib/calls.js
+++ b/lib/calls.js
@@ -112,6 +112,7 @@ module.exports = function(signaller, opts) {
     signaller('call:started', id, pc, data);
 
     // configure the heartbeat timer
+    call.lastping = Date.now();
     heartbeat = heartbeat || require('./heartbeat')(signaller, calls, opts);
 
     // examine the existing remote streams after a short delay

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -10,7 +10,7 @@ module.exports = function(signaller, calls, opts) {
       var call = calls.get(id);
 
       // if the call ping is too old, end the call
-      if (call.lastping < tickInactive) {
+      if (call.active && call.lastping < tickInactive) {
         signaller('call:expired', id, call.pc);
         return calls.end(id);
       }


### PR DESCRIPTION
In the case when ice candidate negotiation takes longer than approx 3*heartbeat the period, qc can sometimes kill the call shortly after negotiation. When the heartbeat check is already running e.g. in the case of a third call participant, this can occur during negotiation.

This happens because lastping is set at construction time in calls.js, but the preriodic transmission of pings doesn't start until the call is started.

This pr attempts to remove these cases by resetting the lastping when the call is started, and limits expiry checks to active calls only.