### PR TITLE
Individual heartbeats, add reconnectTo method

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,6 +185,7 @@ module.exports = function(signalhost, opts) {
     var data = getPeerData(id);
     var pc;
     var monitor;
+    var call;
 
     // if the room is not a match, abort
     if (data.room !== room) {
@@ -204,7 +205,7 @@ module.exports = function(signalhost, opts) {
     signaller('peer:connect', data.id, pc, data);
 
     // add this connection to the calls list
-    calls.create(data.id, pc);
+    call = calls.create(data.id, pc);
 
     // add the local streams
     localStreams.forEach(function(stream) {
@@ -243,6 +244,10 @@ module.exports = function(signalhost, opts) {
       logger: mbus('pc.' + id, signaller)
     }));
 
+    // Apply the monitor to the call
+    call.monitor = monitor;
+
+    // Fire the couple event
     signaller('peer:couple', id, pc, data, monitor);
 
     // once active, trigger the peer connect event
@@ -345,8 +350,7 @@ module.exports = function(signalhost, opts) {
     // then pass this onto the announce handler
     if (id && (! activeCall)) {
       debug('received peer update from peer ' + id + ', no active calls');
-      signaller.to(id).send('/reconnect');
-      return connect(id);
+      return signaller.reconnectTo(id);
     }
   }
 
@@ -672,6 +676,16 @@ module.exports = function(signalhost, opts) {
         callback(null, calls.get(id).pc);
       }
     });
+  };
+
+  /**
+    Attempts to reconnect to a certain target peer. It will close any existing
+    call to that peer, and restart the connection process
+   **/
+  signaller.reconnectTo = function(id) {
+    if (!id) return;
+    signaller.to(id).send('/reconnect');
+    return connect(id);
   };
 
   // if we have an expected number of local streams, then use a filter to

--- a/index.js
+++ b/index.js
@@ -354,6 +354,13 @@ module.exports = function(signalhost, opts) {
     }
   }
 
+  function handlePeerLeave(data) {
+    var id = data && data.id;
+    if (id) {
+      calls.end(id);
+    }
+  }
+
   // if the room is not defined, then generate the room name
   if (! room) {
     // if the hash is not assigned, then create a random hash value
@@ -699,6 +706,10 @@ module.exports = function(signalhost, opts) {
 
   // handle ping messages
   signaller.on('message:ping', calls.ping);
+
+  // Handle when a remote peer leaves that the appropriate closing occurs this
+  // side as well
+  signaller.on('message:leave', handlePeerLeave);
 
   // use genice to find our iceServers
   require('rtc-core/genice')(opts, function(err, servers) {

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -6,16 +6,30 @@ var getable = require('cog/getable');
 module.exports = function(signaller, opts) {
   var calls = getable({});
   var getPeerData = require('./getpeerdata')(signaller.peers);
-  var heartbeat;
+  var heartbeats = require('./heartbeat')(signaller, opts);
 
   function create(id, pc) {
-    calls.set(id, {
+    var heartbeat = heartbeats.create(id);
+    var call = {
       active: false,
+      signalling: false,
       pc: pc,
       channels: getable({}),
       streams: [],
-      lastping: Date.now()
+      lastping: Date.now(),
+      heartbeat: heartbeat
+    };
+    calls.set(id, call);
+
+    // Detect changes to the communication with this peer via
+    // the signaller
+    heartbeat.on('signalling:state', function(connected) {
+      call.signalling = connected;
     });
+
+    // Indicate the call creation
+    signaller('call:created', id, pc);
+    return call;
   }
 
   function createStreamAddHandler(id) {
@@ -42,6 +56,16 @@ module.exports = function(signaller, opts) {
       return;
     }
 
+    // Stop the heartbeat
+    if (call.heartbeat) {
+      call.heartbeat.stop();
+    }
+
+    // If a monitor is attached, remove all listeners
+    if (call.monitor) {
+      call.monitor.clear();
+    }
+
     // if we have no data, then return
     call.channels.keys().forEach(function(label) {
       var channel = call.channels.get(label);
@@ -65,11 +89,6 @@ module.exports = function(signaller, opts) {
     // delete the call data
     calls.delete(id);
 
-    // if we have no more calls, disable the heartbeat
-    if (calls.keys().length === 0) {
-      resetHeartbeat();
-    }
-
     // trigger the call:ended event
     signaller('call:ended', id, call.pc);
 
@@ -83,6 +102,7 @@ module.exports = function(signaller, opts) {
     // set the last ping for the data
     if (call) {
       call.lastping = Date.now();
+      call.heartbeat.touch();
     }
   }
 
@@ -90,11 +110,6 @@ module.exports = function(signaller, opts) {
     return function(stream) {
       signaller('stream:added', id, stream, getPeerData(id));
     };
-  }
-
-  function resetHeartbeat() {
-    clearInterval(heartbeat);
-    heartbeat = 0;
   }
 
   function start(id, pc, data) {
@@ -113,7 +128,12 @@ module.exports = function(signaller, opts) {
 
     // configure the heartbeat timer
     call.lastping = Date.now();
-    heartbeat = heartbeat || require('./heartbeat')(signaller, calls, opts);
+
+    // Monitor the heartbeat for signaller disconnection
+    call.heartbeat.once('disconnected', function() {
+      signaller('call:expired', id, call.pc);
+      return end(id);
+    });
 
     // examine the existing remote streams after a short delay
     process.nextTick(function() {

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -47,10 +47,10 @@ module.exports = function(signaller, opts) {
       Starts the heartbeat
      **/
     heartbeat.start = function() {
-      if (this._timer) heartbeat.stop();
+      if (timer) heartbeat.stop();
       if (delay === 0) return;
 
-      this._timer = setInterval(beat, delay);
+      timer = setInterval(beat, delay);
       beat();
     };
 

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -1,28 +1,87 @@
-module.exports = function(signaller, calls, opts) {
-  var heartbeat = (opts || {}).heartbeat || 2500;
-  var heartbeatTimer = 0;
+var mbus = require('mbus');
 
-  function send() {
-    var tickInactive = (Date.now() - (heartbeat * 4));
+module.exports = function(signaller, opts) {
 
-    // iterate through our established calls
-    calls.keys().forEach(function(id) {
-      var call = calls.get(id);
+  /**
+    Creates a new heartbeat
+   **/
+  function create(id) {
 
-      // if the call ping is too old, end the call
-      if (call.active && call.lastping < tickInactive) {
-        signaller('call:expired', id, call.pc);
-        return calls.end(id);
-      }
+    var heartbeat = mbus();
+    var delay = (opts || {}).heartbeat || 2500;
+    var timer = null;
+    var connected = false;
+    var lastping = 0;
 
-      // send a ping message
+    /**
+      Pings the target peer
+     **/
+    function ping() {
       signaller.to(id).send('/ping');
-    });
+    }
+
+    /**
+      Checks the state of the signaller connection
+     **/
+    function check() {
+      var tickInactive = (Date.now() - (delay * 4));
+
+      var currentlyConnected = lastping >= tickInactive;
+      // If we have changed connection state, flag the change
+      if (connected !== currentlyConnected) {
+        heartbeat(currentlyConnected ? 'connected' : 'disconnected');
+        heartbeat('signalling:state', currentlyConnected);
+        connected = currentlyConnected;
+      }
+    }
+
+    /**
+      Checks the state of the connection, and pings as well
+     **/
+    function beat() {
+      check();
+      ping();
+    }
+
+    /**
+      Starts the heartbeat
+     **/
+    heartbeat.start = function() {
+      if (this._timer) heartbeat.stop();
+      if (delay === 0) return;
+
+      this._timer = setInterval(beat, delay);
+      beat();
+    };
+
+    /**
+      Stops the heartbeat
+     **/
+    heartbeat.stop = function() {
+      if (timer) clearInterval(timer);
+    };
+
+    /**
+      Registers the receipt on a ping
+     **/
+    heartbeat.touch = function() {
+      lastping = Date.now();
+      check();
+    };
+
+    /**
+      Updates the delay interval
+     **/
+    heartbeat.updateDelay = function(value) {
+      delay = value;
+      heartbeat.start();
+    };
+
+    heartbeat.start();
+    return heartbeat;
   }
 
-  if (! heartbeat) {
-    return;
-  }
-
-  return setInterval(send, heartbeat);
+  return {
+    create: create
+  };
 };


### PR DESCRIPTION
Heartbeats are now run independently of each other, and also track the state of the signalling channel to each peer. Heartbeats are also initiated on call creation, meaning that it is possible in the event of P2P connectivity failure to implicitly determine expected peers/connected peers with accuracy.

Also exposes a `reconnectTo` method, which will trigger a refresh of the connection to the given peer. 

Handles `message:leave` messages for quicker close response.