### PR TITLE
Asynchronous ICE servers generation + schemes

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ module.exports = function(signalhost, opts) {
     // end any call to this id so we know we are starting fresh
     calls.end(id);
     // Regenerate ICE servers (or use existing cached ICE)
-    generateIceServers(extend({targetPeer: id}, opts, (scheme || {}).config), function(err, iceServers) {
+    generateIceServers(extend({targetPeer: id}, opts, (scheme || {}).connection), function(err, iceServers) {
       if (err) {
         signaller('icegeneration:error', id, scheme && scheme.id, err);
       } else {
@@ -564,9 +564,7 @@ module.exports = function(signalhost, opts) {
 
     Registers a connection scheme for use, and check it for validity
    **/
-  signaller.registerScheme = function registerScheme (scheme) {
-    return schemes.add(scheme);
-  };
+  signaller.registerScheme = schemes.add;
 
   /**
     #### removeStream

--- a/index.js
+++ b/index.js
@@ -199,11 +199,10 @@ module.exports = function(signalhost, opts) {
 
     // Regenerate ICE servers (or use existing cached ICE)
     generateIceServers(extend({targetPeer: id}, opts, (scheme || {}).config), function(err, iceServers) {
-
-      if (err || !iceServers || !Array.isArray(iceServers) || iceServers.length === 0) {
-        console.error('Unable to get ICE servers', err);
-        signaller('peer:noice', data.id, err);
-        return;
+      if (err) {
+        signaller('icegeneration:error', id, schemeId, err);
+      } else {
+        signaller('peer:iceservers', id, schemeId, iceServers || []);
       }
 
       // create a peer connection

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -94,6 +94,7 @@ module.exports = function(signaller, opts) {
 
     // trigger the call:ended event
     signaller('call:ended', id, call.pc);
+    signaller('call:' + id + ':ended', call.pc);
 
     // ensure the peer connection is properly cleaned up
     cleanup(call.pc);

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -42,9 +42,12 @@ module.exports = function(signaller, opts) {
 
   function createStreamRemoveHandler(id) {
     return function(evt) {
+      console.log('stream removed for %s', id);
       debug('peer ' + id + ' removed stream');
       updateRemoteStreams(id);
+      console.log('stream 1', id);
       signaller('stream:removed', id, evt.stream);
+      console.log('stream 2', id);
     };
   }
 

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -42,12 +42,9 @@ module.exports = function(signaller, opts) {
 
   function createStreamRemoveHandler(id) {
     return function(evt) {
-      console.log('stream removed for %s', id);
       debug('peer ' + id + ' removed stream');
       updateRemoteStreams(id);
-      console.log('stream 1', id);
       signaller('stream:removed', id, evt.stream);
-      console.log('stream 2', id);
     };
   }
 

--- a/lib/schemes.js
+++ b/lib/schemes.js
@@ -23,7 +23,7 @@ module.exports = function(signaller, opts) {
       throw new Error('Scheme ' + schemeId + ' already exists');
     }
     // Check default
-    if (scheme.default) {
+    if (scheme.isDefault) {
       if (_default) {
         console.warn('Default scheme already exists');
       } else {
@@ -32,7 +32,6 @@ module.exports = function(signaller, opts) {
     }
 
     schemes[scheme.id] = scheme;
-    debug('scheme added %s', scheme.id, scheme);
   }
 
   /**

--- a/lib/schemes.js
+++ b/lib/schemes.js
@@ -1,0 +1,55 @@
+var rtc = require('rtc-tools');
+var debug = rtc.logger('rtc-quickconnect');
+
+/**
+  Schemes allow multiple connection schemes for selection when attempting to connect to
+  a peer
+ **/
+module.exports = function(signaller, opts) {
+
+	var schemes = {};
+	var _default;
+
+	/**
+	  Adds a connection scheme
+	 **/
+	function add(scheme) {
+		// Ensure valid ID
+		if (!scheme || !scheme.id || typeof scheme.id !== 'string') {
+			throw new Error('Cannot add invalid scheme. Requires at least an ID');
+		}
+		// Unique schemes
+		if (schemes[scheme.id]) {
+			throw new Error('Scheme ' + schemeId + ' already exists');
+		}
+		// Check default
+		if (scheme.default) {
+			if (_default) {
+				console.warn('Default scheme already exists');
+			} else {
+				_default = scheme.id;
+			}
+		}
+
+		schemes[scheme.id] = scheme;
+		debug('scheme added', scheme);
+	}
+
+	/**
+	  Returns the scheme with the given ID. If canDefault is true it will return the default scheme
+	  if no scheme with ID is found
+	 **/
+	function get(id, canDefault) {
+		return schemes[id] || (canDefault && _default ? schemes[_default] : undefined);
+	}
+
+	// Load passed in schemes
+	if (opts && opts.schemes && Array.isArray(opts.schemes)) {
+		opts.schemes.forEach(add);
+	}
+
+	return {
+		add: add,
+		get: get
+	};
+};

--- a/lib/schemes.js
+++ b/lib/schemes.js
@@ -7,49 +7,49 @@ var debug = rtc.logger('rtc-quickconnect');
  **/
 module.exports = function(signaller, opts) {
 
-	var schemes = {};
-	var _default;
+  var schemes = {};
+  var _default;
 
-	/**
-	  Adds a connection scheme
-	 **/
-	function add(scheme) {
-		// Ensure valid ID
-		if (!scheme || !scheme.id || typeof scheme.id !== 'string') {
-			throw new Error('Cannot add invalid scheme. Requires at least an ID');
-		}
-		// Unique schemes
-		if (schemes[scheme.id]) {
-			throw new Error('Scheme ' + schemeId + ' already exists');
-		}
-		// Check default
-		if (scheme.default) {
-			if (_default) {
-				console.warn('Default scheme already exists');
-			} else {
-				_default = scheme.id;
-			}
-		}
+  /**
+    Adds a connection scheme
+   **/
+  function add(scheme) {
+    // Ensure valid ID
+    if (!scheme || !scheme.id || typeof scheme.id !== 'string') {
+      throw new Error('Cannot add invalid scheme. Requires at least an ID');
+    }
+    // Unique schemes
+    if (schemes[scheme.id]) {
+      throw new Error('Scheme ' + schemeId + ' already exists');
+    }
+    // Check default
+    if (scheme.default) {
+      if (_default) {
+        console.warn('Default scheme already exists');
+      } else {
+        _default = scheme.id;
+      }
+    }
 
-		schemes[scheme.id] = scheme;
-		debug('scheme added', scheme);
-	}
+    schemes[scheme.id] = scheme;
+    debug('scheme added %s', scheme.id, scheme);
+  }
 
-	/**
-	  Returns the scheme with the given ID. If canDefault is true it will return the default scheme
-	  if no scheme with ID is found
-	 **/
-	function get(id, canDefault) {
-		return schemes[id] || (canDefault && _default ? schemes[_default] : undefined);
-	}
+  /**
+    Returns the scheme with the given ID. If canDefault is true it will return the default scheme
+    if no scheme with ID is found
+   **/
+  function get(id, canDefault) {
+    return schemes[id] || (canDefault && _default ? schemes[_default] : undefined);
+  }
 
-	// Load passed in schemes
-	if (opts && opts.schemes && Array.isArray(opts.schemes)) {
-		opts.schemes.forEach(add);
-	}
+  // Load passed in schemes
+  if (opts && opts.schemes && Array.isArray(opts.schemes)) {
+    opts.schemes.forEach(add);
+  }
 
-	return {
-		add: add,
-		get: get
-	};
+  return {
+    add: add,
+    get: get
+  };
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rtc-filter-grayscale": "~0.1.0",
     "rtc-media": "^1",
     "rtc-plugin-temasys": "^1.1.1",
-    "rtc-quickconnect-test": "^1.2.1",
+    "rtc-quickconnect-test": "^1.3.0",
     "rtc-switchboard": "^3.0.0",
     "rtc-videoproc": "^0.11.0",
     "tap-spec": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rtc-filter-grayscale": "~0.1.0",
     "rtc-media": "^1",
     "rtc-plugin-temasys": "^1.1.1",
-    "rtc-quickconnect-test": "^1.3.0",
+    "rtc-quickconnect-test": "^2.0.0",
     "rtc-switchboard": "^3.0.0",
     "rtc-videoproc": "^0.11.0",
     "tap-spec": "^3.0.0",


### PR DESCRIPTION
This moves the generation of the ICE server list from the creation of the quickconnect instance to the point just prior to connection, allowing for the generation of custom ICE servers based on the peer ID, as well as the use of short lived credentials.

It also introduces the concept of connection schemes. Schemes are an optional way of defining connection parameters - for instance, an example use case might be two different sets of ICE servers that should only be used when different criteria are met.

In order for connections to be successfully established when using schemes, quickconnect now communicates a set of connection options to be used when attempting the establishment of a connection, which includes a scheme. (it is currently the only option, but it is left open for future enhancement).

The other thing to note is that each quickconnect peer must provide the appropriate set of schemes. Two peers with different sets of schemes will not be able to communicate.

While this is a drop in replacement (ie. the previous `ice` and `iceServers` options will still work, however will be loaded asynchronously now), it is intended that this be a major version bump to `5.0.0`.

Tests for schemes can be found in the PR against `rtc-quickconnect-test` https://github.com/rtc-io/rtc-quickconnect-test/pull/4