### PR TITLE
Improved failure handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ module.exports = function(signalhost, opts) {
     // older switchboard instance
     endpoints: ['/', '/primus']
   }, opts));
+
   var getPeerData = require('./lib/getpeerdata')(signaller.peers);
   var generateIceServers = require('rtc-core/genice');
 
@@ -388,9 +389,9 @@ module.exports = function(signalhost, opts) {
     }
   }
 
-  function handlePeerClose() {
+  function handlePeerClose(id) {
     if (!announced) return;
-    debug('call has ended, reannouncing to synchronize connections');
+    debug('call has from ' + signaller.id + ' to ' + id + ' has ended, reannouncing');
     return signaller.profile();
   }
 
@@ -715,7 +716,7 @@ module.exports = function(signalhost, opts) {
     if (announced) {
       clearTimeout(updateTimer);
       updateTimer = setTimeout(function() {
-        debug('reannouncing');
+        debug('[' + signaller.id + '] reannouncing');
         signaller.announce(profile);
       }, (opts || {}).updateDelay || 1000);
     }

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -9,7 +9,7 @@ module.exports = function(signaller, opts) {
   var heartbeats = require('./heartbeat')(signaller, opts);
   var debugPrefix = '[' + signaller.id + '] ';
 
-  function create(id, pc) {
+  function create(id, pc, data) {
     var heartbeat = heartbeats.create(id);
     var call = {
       active: false,
@@ -30,7 +30,7 @@ module.exports = function(signaller, opts) {
 
     // Indicate the call creation
     debug(debugPrefix + 'call has been created for ' + id + ' (not yet started)');
-    signaller('call:created', id, pc);
+    signaller('call:created', id, pc, data);
     return call;
   }
 

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -7,6 +7,7 @@ module.exports = function(signaller, opts) {
   var calls = getable({});
   var getPeerData = require('./getpeerdata')(signaller.peers);
   var heartbeats = require('./heartbeat')(signaller, opts);
+  var debugPrefix = '[' + signaller.id + '] ';
 
   function create(id, pc) {
     var heartbeat = heartbeats.create(id);
@@ -28,14 +29,14 @@ module.exports = function(signaller, opts) {
     });
 
     // Indicate the call creation
-    debug('call has been created for ' + id + ' (not yet started)');
+    debug(debugPrefix + 'call has been created for ' + id + ' (not yet started)');
     signaller('call:created', id, pc);
     return call;
   }
 
   function createStreamAddHandler(id) {
     return function(evt) {
-      debug('peer ' + id + ' added stream');
+      debug(debugPrefix + 'peer ' + id + ' added stream');
       updateRemoteStreams(id);
       receiveRemoteStream(id)(evt.stream);
     };
@@ -43,7 +44,7 @@ module.exports = function(signaller, opts) {
 
   function createStreamRemoveHandler(id) {
     return function(evt) {
-      debug('peer ' + id + ' removed stream');
+      debug(debugPrefix + 'peer ' + id + ' removed stream');
       updateRemoteStreams(id);
       signaller('stream:removed', id, evt.stream);
     };
@@ -61,7 +62,7 @@ module.exports = function(signaller, opts) {
       return;
     }
 
-    debug('call is failing for ' + id);
+    debug(debugPrefix + 'call is failing for ' + id);
     signaller('call:failing', id, call && call.pc);
   }
 
@@ -77,7 +78,7 @@ module.exports = function(signaller, opts) {
       return;
     }
 
-    debug('call has recovered for ' + id);
+    debug(debugPrefix + 'call has recovered for ' + id);
     signaller('call:recovered', id, call && call.pc);
   }
 
@@ -88,7 +89,7 @@ module.exports = function(signaller, opts) {
       return;
     }
 
-    debug('call has failed for ' + id);
+    debug(debugPrefix + 'call has failed for ' + id);
     signaller('call:failed', id, call && call.pc);
     end(id);
   }
@@ -135,7 +136,7 @@ module.exports = function(signaller, opts) {
     calls.delete(id);
 
     // trigger the call:ended event
-    debug('call has ended for ' + id);
+    debug(debugPrefix + 'call has ended for ' + id);
     signaller('call:ended', id, call.pc);
     signaller('call:' + id + ':ended', call.pc);
 
@@ -170,10 +171,8 @@ module.exports = function(signaller, opts) {
     pc.onaddstream = createStreamAddHandler(id);
     pc.onremovestream = createStreamRemoveHandler(id);
 
-    debug(signaller.id + ' - ' + id + ' call start: ' + streams.length + ' streams');
-    debug('call has started for ' + id);
+    debug(debugPrefix + ' -> ' + id + ' call start: ' + streams.length + ' streams');
     signaller('call:started', id, pc, data);
-    console.log(pc);
 
     // configure the heartbeat timer
     call.lastping = Date.now();

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -49,8 +49,45 @@ module.exports = function(signaller, opts) {
     };
   }
 
+  /**
+    Failing is invoked when a call in the process of failing, usually as a result
+    of a disconnection in the PeerConnection. A connection that is failing can
+    be recovered, however, encountering this state does indicate the call is in trouble
+   **/
+  function failing(id) {
+    var call = calls.get(id);
+    // If no call exists, do nothing
+    if (!call) {
+      return;
+    }
+
+    debug('call is failing for ' + id);
+    signaller('call:failing', id, call && call.pc);
+  }
+
+  /**
+    Recovered is invoked when a call which was previously failing has recovered. Namely,
+    the PeerConnection has been restored by connectivity being reestablished (primary cause
+    would probably be network connection drop outs, such as WiFi)
+   **/
+  function recovered(id) {
+    var call = calls.get(id);
+    // If no call exists, do nothing
+    if (!call) {
+      return;
+    }
+
+    debug('call has recovered for ' + id);
+    signaller('call:recovered', id, call && call.pc);
+  }
+
   function fail(id) {
     var call = calls.get(id);
+    // If no call exists, do nothing
+    if (!call) {
+      return;
+    }
+
     debug('call has failed for ' + id);
     signaller('call:failed', id, call && call.pc);
     end(id);
@@ -136,6 +173,7 @@ module.exports = function(signaller, opts) {
     debug(signaller.id + ' - ' + id + ' call start: ' + streams.length + ' streams');
     debug('call has started for ' + id);
     signaller('call:started', id, pc, data);
+    console.log(pc);
 
     // configure the heartbeat timer
     call.lastping = Date.now();
@@ -164,8 +202,10 @@ module.exports = function(signaller, opts) {
   calls.create = create;
   calls.end = end;
   calls.fail = fail;
+  calls.failing = failing;
   calls.ping = ping;
   calls.start = start;
+  calls.recovered = recovered;
 
   return calls;
 };


### PR DESCRIPTION
Uses the `failing` and `recovered` events from `rtc-tools/couple` to provide for `call:failing` and `call:recovered` events - which will allow for improved UI handling of connection difficulties.

Adds a `handlePeerClose` function that is triggered on `call:ended`, which will reannounce, and thereby allowing reconnections to any peers connected to the signaller that are not currently connected to.

`qc.leave()` now sets the `announced` property to false, to prevent accidental rejoins after leaving.