### PR TITLE
`removeStream` improvements for Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ node_js:
 - stable
 
 env:
+  global:
+    - CXX=g++-4.8
   matrix:
     - BROWSER=chrome  BVER=stable
     - BROWSER=chrome  BVER=beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,10 @@ after_failure:
 notifications:
   email:
   - nathan.oehlman@nicta.com.au
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/index.js
+++ b/index.js
@@ -626,7 +626,30 @@ module.exports = function(signalhost, opts) {
 
     // remove the stream from any active calls
     calls.values().forEach(function(call) {
-      call.pc.removeStream(stream);
+
+      // If `RTCPeerConnection.removeTrack` exists (Firefox), then use that
+      // as `RTCPeerConnection.removeStream` is not supported
+      if (call.pc.removeTrack) {
+        stream.getTracks().forEach(function(track) {
+          try {
+            call.pc.removeTrack(track);
+          } catch (e) {
+            // When using LocalMediaStreamTracks, this seems to throw an error due to
+            // LocalMediaStreamTrack not implementing the RTCRtpSender inteface.
+            // Without `removeStream` and with `removeTrack` not allowing for local stream
+            // removal, this needs some thought when dealing with FF renegotiation
+            console.error('Error removing media track', e);
+          }
+        });
+      }
+      // Otherwise we just use `RTCPeerConnection.removeStream`
+      else {
+        try {
+          call.pc.removeStream(stream);
+        } catch (err) {
+          console.error('Failed to remove media stream', e);
+        }
+      }
     });
 
     // remove the stream from the localStreams array

--- a/index.js
+++ b/index.js
@@ -646,7 +646,7 @@ module.exports = function(signalhost, opts) {
       else {
         try {
           call.pc.removeStream(stream);
-        } catch (err) {
+        } catch (e) {
           console.error('Failed to remove media stream', e);
         }
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "async": "^0.9",
     "attachmediastream": "^1.0.1",
     "broth": "^2.2.0",
-    "browserify": "^9.0.3",
+    "browserify": "^13.0.0",
     "crel": "^2.1.5",
     "fdom": "^1.2.0",
     "freeice": "^2.1.1",


### PR DESCRIPTION
Calling `qc.removeStream` on Firefox will currently throw a `Not yet implemented` exception on Firefox, and according to https://bugzilla.mozilla.org/show_bug.cgi?id=842455, `removeStream` has been removed in favour of `removeTrack`.

This adds better handling around the `qc.removeStream` functionality to test if the `RTCPeerConnection.removeTrack` function is available, and if so, use that. Otherwise, use the existing `RTCPeerConnection.removeStream`. As a part of this, wraps the removal in `try...catch` to prevent killing everything.