### PR TITLE
Fixes reconnections when a call has not yet connected/failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -635,6 +635,13 @@ module.exports = function(signalhost, opts) {
   signaller.registerScheme = schemes.add;
 
   /**
+   #### getSche,e
+
+   Returns the connection sheme given by ID
+  **/
+  signaller.getScheme = schemes.get;
+
+  /**
     #### removeStream
 
     ```

--- a/index.js
+++ b/index.js
@@ -280,8 +280,11 @@ module.exports = function(signalhost, opts) {
         calls.start(id, pc, data);
       });
       monitor.once('closed', function() {
-        clearPending('closed');;
+        clearPending('closed');
         calls.end(id);
+      });
+      monitor.once('aborted', function() {
+        clearPending('aborted');
       });
       monitor.once('failed', calls.fail.bind(null, id));
 
@@ -442,7 +445,10 @@ module.exports = function(signalhost, opts) {
       data = undefined;
     }
 
+    // Abort any current calls
+    calls.abort(sender.id);
     connect(sender.id, data || {});
+
     // If this is the master, echo the reconnection back to the peer instructing that
     // the reconnection has been accepted and to connect
     var isMaster = signaller.isMaster(sender.id);
@@ -803,6 +809,8 @@ module.exports = function(signalhost, opts) {
     // message back instructing the connection to start
     var isMaster = signaller.isMaster(id);
     if (isMaster) {
+      // Abort any current calls
+      calls.abort(id);
       return connect(id, reconnectOpts);
     }
   };

--- a/index.js
+++ b/index.js
@@ -183,9 +183,13 @@ module.exports = function(signalhost, opts) {
   }
 
   function clearPending(msg) {
-    if (!pending[id]) return;
     debug('connection for ' + id + ' is no longer pending [' + (msg || 'no reason') + '], connect available again');
-    delete pending[id];
+    if (pending[id]) {
+      delete pending[id];
+    }
+    if (reconnecting[id]) {
+      delete reconnecting[id];
+    }
   }
 
   function connect(id, connectOpts) {

--- a/index.js
+++ b/index.js
@@ -450,6 +450,7 @@ module.exports = function(signalhost, opts) {
 
     // Abort any current calls
     calls.abort(sender.id);
+    signaller('peer:reconnecting', sender.id, data || {});
     connect(sender.id, data || {});
 
     // If this is the master, echo the reconnection back to the peer instructing that
@@ -812,8 +813,10 @@ module.exports = function(signalhost, opts) {
     // message back instructing the connection to start
     var isMaster = signaller.isMaster(id);
     if (isMaster) {
+
       // Abort any current calls
       calls.abort(id);
+      signaller('peer:reconnecting', id, reconnectOpts || {});
       return connect(id, reconnectOpts);
     }
   };

--- a/index.js
+++ b/index.js
@@ -443,6 +443,7 @@ module.exports = function(signalhost, opts) {
 
     // Sender arguments are always last
     if (!message) {
+      console.log('message:reconnect no message argument');
       message = sender;
       sender = data;
       data = undefined;
@@ -450,6 +451,7 @@ module.exports = function(signalhost, opts) {
 
     // Abort any current calls
     calls.abort(sender.id);
+    console.log('2. reconnecting to ' + sender.id + ' with ' + JSON.stringify(data || {}));
     signaller('peer:reconnecting', sender.id, data || {});
     connect(sender.id, data || {});
 
@@ -816,6 +818,7 @@ module.exports = function(signalhost, opts) {
 
       // Abort any current calls
       calls.abort(id);
+      console.log('1. reconnecting to ' + id + ' with ' + JSON.stringify(reconnectOpts || {}));
       signaller('peer:reconnecting', id, reconnectOpts || {});
       return connect(id, reconnectOpts);
     }

--- a/index.js
+++ b/index.js
@@ -410,6 +410,7 @@ module.exports = function(signalhost, opts) {
     // then pass this onto the announce handler
     if (id && (! activeCall) && !pending[id] && !reconnecting[id]) {
       debug('received peer update from peer ' + id + ', no active calls');
+      signaller('peer:autoreconnect', id);
       return signaller.reconnectTo(id);
     }
   }
@@ -838,7 +839,13 @@ module.exports = function(signalhost, opts) {
     if (isMaster) {
 
       // Abort any current calls
-      calls.abort(id);
+      signaller('log', 'aborting call');
+      try {
+        calls.abort(id);
+      } catch(e) {
+        signaller('log', e.message);
+      }
+      signaller('log', 'call aborted');
       signaller('peer:reconnecting', id, reconnectOpts || {});
       return connect(id, reconnectOpts);
     }

--- a/index.js
+++ b/index.js
@@ -286,7 +286,10 @@ module.exports = function(signalhost, opts) {
       monitor.once('aborted', function() {
         clearPending('aborted');
       });
-      monitor.once('failed', calls.fail.bind(null, id));
+      monitor.once('failed', function() {
+        clearPending('failed');
+        calls.fail(id);
+      });
 
       // The following states are intermediate states based on the disconnection timer
       monitor.once('failing', calls.failing.bind(null, id));

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -94,6 +94,19 @@ module.exports = function(signaller, opts) {
     end(id);
   }
 
+  /**
+    Stops the coupling process for a call
+   **/
+  function abort(id) {
+    var call = calls.get(id);
+    // If no call, do nothing
+    if (!call) return;
+
+    if (call.monitor) call.monitor.abort();
+    signaller('call:aborted', id, call && call.pc);
+    end(id);
+  }
+
   function end(id) {
     var call = calls.get(id);
 
@@ -109,7 +122,7 @@ module.exports = function(signaller, opts) {
 
     // If a monitor is attached, remove all listeners
     if (call.monitor) {
-      call.monitor.clear();
+      call.monitor.stop();
     }
 
     // if we have no data, then return
@@ -198,6 +211,7 @@ module.exports = function(signaller, opts) {
     }
   }
 
+  calls.abort = abort;
   calls.create = create;
   calls.end = end;
   calls.fail = fail;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rtc-capture": "^1.0.2",
     "rtc-core": "^4.0.0",
     "rtc-pluggable-signaller": "^2.0.0",
-    "rtc-tools": "^5.0.0"
+    "rtc-tools": "^5.2.0"
   },
   "devDependencies": {
     "async": "^0.9",

--- a/test/all.js
+++ b/test/all.js
@@ -8,7 +8,9 @@ function createSignaller(opts) {
   }, opts));
 }
 
-require('rtc-quickconnect-test')(
-  require('..'),
-  createSignaller
-);
+for (var i = 0; i < 2; i++) {
+	require('rtc-quickconnect-test')(
+	  require('..'),
+	  createSignaller
+	);
+}

--- a/test/all.js
+++ b/test/all.js
@@ -8,9 +8,7 @@ function createSignaller(opts) {
   }, opts));
 }
 
-for (var i = 0; i < 2; i++) {
-	require('rtc-quickconnect-test')(
-	  require('..'),
-	  createSignaller
-	);
-}
+require('rtc-quickconnect-test')(
+  require('..'),
+  createSignaller
+);


### PR DESCRIPTION
Uses the coupling abort functionality in https://github.com/rtc-io/rtc-tools/pull/45 to allow reconnections to manually abort pre-existing connection attempts before attempting to reconnect.

Currently, if a reconnection was attempted while an existing connection had not yet connected/closed, it would not be allowed due to the outstanding connection flag.