### PR TITLE
Handle "stuck" data channels

### DIFF
--- a/index.js
+++ b/index.js
@@ -327,6 +327,7 @@ module.exports = function(signalhost, opts) {
 
   function gotPeerChannel(channel, pc, data) {
     var channelMonitor;
+    var channelConnectionTimer;
 
     function channelReady() {
       var call = calls.get(data.id);
@@ -335,6 +336,7 @@ module.exports = function(signalhost, opts) {
       // decouple the channel.onopen listener
       debug('reporting channel "' + channel.label + '" ready, have call: ' + (!!call));
       clearInterval(channelMonitor);
+      clearTimeout(channelConnectionTimer);
       channel.onopen = null;
 
       // save the channel
@@ -355,6 +357,23 @@ module.exports = function(signalhost, opts) {
       );
     }
 
+    // If the channel has failed to create for some reason, recreate the channel
+    function channelFailed() {
+      debug('failed to open channel ' + channel.label + ', retrying');
+
+      // Clear timers
+      clearInterval(channelMonitor);
+      clearTimeout(channelConnectionTimer);
+
+      // Force the channel to close if it is in an open state
+      if (['connecting', 'open'].indexOf(channel.readyState) !== -1) {
+        channel.close();
+      }
+
+      // Recreate the channel using the cached options
+      signaller.createDataChannel(channel.label, channels[channel.label])
+    }
+
     debug('channel ' + channel.label + ' discovered for peer: ' + data.id);
     if (channel.readyState === 'open') {
       return channelReady();
@@ -368,10 +387,19 @@ module.exports = function(signalhost, opts) {
       debug('checking channel state, current state = ' + channel.readyState + ', connection state ' + pc.iceConnectionState);
       if (channel.readyState === 'open') {
         channelReady();
-      } else if (['failed', 'closed'].indexOf(pc.iceConnectionState) !== -1) {
+      }
+      // If the underlying connection has failed/closed, then terminate the monitor
+      else if (['failed', 'closed'].indexOf(pc.iceConnectionState) !== -1) {
         debug('connection has terminated, cancelling channel monitor');
         clearInterval(channelMonitor);
+        clearTimeout(channelConnectionTimer);
       }
+      // If the connection has connected, but the channel is stuck in the connecting state
+      // start a timer. If this expires, then we will attempt to created the data channel
+      else if (pc.iceConnectionState === 'connected' && channel.readyState === 'connecting' && !channelConnectionTimer) {
+        channelConnectionTimer = setTimeout(channelFailed, (opts || {}).channelTimeout || 1000);
+      }
+
     }, 500);
   }
 


### PR DESCRIPTION
In some instances (particularly when dealing with renegotiated connections), a data channel will get stuck in the `connecting` ready state, despite the underlying peer connection having been successfully connected.

The result of this is the master peer creating the data channel, but not using it (due to it not being ready yet), while the client peer will never receive the channel, due to the `ondatachannel` event of the PeerConnection never being fired.

This PR adds a timeout to the `gotPeerChannel` function responsible for checking to see whether the data channel has been connected. If the underlying peer connection is `connected` and the monitored data channel has the `connecting` readyState, it attempts to recreate the data channel, and hopefully, successfully establish the channel.