### PR TITLE
Clear pending calls upon peer leave/close

### DIFF
--- a/index.js
+++ b/index.js
@@ -460,12 +460,14 @@ module.exports = function(signalhost, opts) {
   function handlePeerLeave(data) {
     var id = data && data.id;
     if (id) {
+      delete pending[id];
       calls.end(id);
     }
   }
 
   function handlePeerClose(id) {
     if (!announced) return;
+    delete pending[id];
     debug('call has from ' + signaller.id + ' to ' + id + ' has ended, reannouncing');
     return signaller.profile();
   }


### PR DESCRIPTION
I noticed that sometimes rtc-quickconnect gets into a state where calls are never actually tried because of [this check](https://github.com/rtc-io/rtc-quickconnect/blob/66d93987eae2c8ebab242181f620b18f72c5fe25/index.js#L188-L192). The [clearPending](https://github.com/rtc-io/rtc-quickconnect/blob/66d93987eae2c8ebab242181f620b18f72c5fe25/index.js#L213-L221) does not get called in all cases where a connection might have dropped. I have not spent the time to analyse as to why, so this PR might not be the cleanest solution. Tests pass after this change. I have not taken the time (nor will I be able to) to reproduce it in a failing test case, but we are using this library in a product and this behaviour broke the app and the changes in this patch fixed it for us.