### PR TITLE
Fixes disabling of heartbeat

### DIFF
--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -60,7 +60,9 @@ module.exports = function(signaller, opts) {
       Stops the heartbeat
      **/
     heartbeat.stop = function() {
-      if (timer) clearInterval(timer);
+      if (!timer) return;
+      clearInterval(timer);
+      timer = null;
     };
 
     /**

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -2,13 +2,15 @@ var mbus = require('mbus');
 
 module.exports = function(signaller, opts) {
 
+  opts = opts || {};
+
   /**
     Creates a new heartbeat
    **/
   function create(id) {
 
     var heartbeat = mbus();
-    var delay = (opts || {}).heartbeat || 2500;
+    var delay = (typeof opts.heartbeat === 'number' ? opts.heartbeat : 2500);
     var timer = null;
     var connected = false;
     var lastping = 0;
@@ -48,7 +50,7 @@ module.exports = function(signaller, opts) {
      **/
     heartbeat.start = function() {
       if (timer) heartbeat.stop();
-      if (delay === 0) return;
+      if (delay <= 0) return;
 
       timer = setInterval(beat, delay);
       beat();


### PR DESCRIPTION
Fixes it so the heartbeat can be disabled by passing in `{ heartbeat: 0}`, or preferably `{heartbeat: -1}`.

Also includes @markjrodrigues changes for ensuring the timer is cleared correctly.