### PR TITLE
Garbage collection improvements

### DIFF
--- a/lib/calls.js
+++ b/lib/calls.js
@@ -145,6 +145,7 @@ module.exports = function(signaller, opts) {
       signaller('stream:removed', id, stream);
     });
 
+    call.monitor.destroy();
     call.monitor = null;
     call.pc = null;
     call.heartbeat = null;

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -117,7 +117,7 @@ module.exports = function(signaller, opts) {
 
     // Stop the heartbeat
     if (call.heartbeat) {
-      call.heartbeat.stop();
+      call.heartbeat.destroy();
     }
 
     // If a monitor is attached, remove all listeners
@@ -144,6 +144,11 @@ module.exports = function(signaller, opts) {
     call.streams.forEach(function(stream) {
       signaller('stream:removed', id, stream);
     });
+
+    call.monitor = null;
+    call.pc = null;
+    call.heartbeat = null;
+    call.active = false;
 
     // delete the call data
     calls.delete(id);

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -27,6 +27,8 @@ module.exports = function(signaller, opts) {
       Checks the state of the signaller connection
      **/
     function check() {
+      if (!heartbeat) return;
+
       var tickInactive = (Date.now() - (delay * 4)); //doesnt always work
 
       var currentlyConnected = ignoreDisconnection ? ignoreDisconnection : (lastping >= tickInactive);
@@ -65,6 +67,16 @@ module.exports = function(signaller, opts) {
       clearInterval(timer);
       timer = null;
     };
+
+    /**
+      Destroys the heartbeat
+     **/
+    heartbeat.destroy = function() {
+      // Stop the heartbeat
+      heartbeat.stop();
+      // Destroy the mbus events
+      heartbeat.clear();
+    }
 
     /**
       Registers the receipt on a ping

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rtc-capture": "^1.0.2",
     "rtc-core": "^4.0.0",
     "rtc-pluggable-signaller": "^2.0.0",
-    "rtc-tools": "^5.2.0"
+    "rtc-tools": "^5.4.0"
   },
   "devDependencies": {
     "async": "^0.9",


### PR DESCRIPTION
In an attempt to help prevent peer connection instances from not being garbage collected, this sets call property references to null prior to deleting the call, as well as clearing up the heartbeat and monitor instances.

This results in the PeerConnection instances able to be cleaned up.

The screenshots attached show the output of the Chrome profiler in a call between 2 peers.

In the first screenshot, there are 3 RTCPeerConnection objects in the the heap. `1951` represents the PeerConnection instance for the connection between the clients. `63099` is the prototype object that is referenced from instances of RTCPeerConnection, and `124955` is something that I'm not quite sure what it is, but is associated with `63099` prototype object - it seems to be created in all situations where the RTCPeerConnection prototype object exists. 

<img width="1078" alt="screenshot 2016-10-14 17 15 28" src="https://cloud.githubusercontent.com/assets/297086/19378974/10858726-9233-11e6-9223-f0b9229c05c0.png">

The second screenshot shows the situation after closing the other peer and the peer connection has been terminated. Note that `1951` (the peer connection instance) has been removed.

<img width="1078" alt="screenshot 2016-10-14 17 17 00" src="https://cloud.githubusercontent.com/assets/297086/19379131/e12bcb74-9233-11e6-9971-cc6b2a5d7dd1.png">

Third screenshot shows the comparison of the two heaps, showing that an RTCPeerConnection object was deleted.
<img width="1064" alt="screenshot 2016-10-14 17 2
4 02" src="https://cloud.githubusercontent.com/assets/297086/19378972/102c5b06-9233-11e6-90e1-0d8f6c5636ec.png">