### PR TITLE
Prevent multiple data channels with the same name from being created

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,10 +343,20 @@ module.exports = function(signalhost, opts) {
       if (call) {
         call.channels.set(channel.label, channel);
 
-        // Remove the channel from the call on close
+        // Remove the channel from the call on close, and emit the required events
         channel.onclose = function() {
           debug('channel "' + channel.label + '" to ' + data.id + ' has closed');
+          var args = [data.id, channel, channel.label];
+          // decouple the events
+          channel.onopen = null;
+          // Remove the channel entry
           call.channels.remove(channel.label);
+
+          // emit the plain channel:closed event
+          signaller.apply(signaller, ['channel:closed'].concat(args));
+
+          // emit the labelled version of the event
+          signaller.apply(signaller, ['channel:closed:' + channel.label].concat(args));
         }
       }
 

--- a/lib/calls.js
+++ b/lib/calls.js
@@ -125,19 +125,10 @@ module.exports = function(signaller, opts) {
       call.monitor.stop();
     }
 
-    // if we have no data, then return
+    // Close any datachannels that are still open
     call.channels.keys().forEach(function(label) {
       var channel = call.channels.get(label);
-      var args = [id, channel, label];
-
-      // emit the plain channel:closed event
-      signaller.apply(signaller, ['channel:closed'].concat(args));
-
-      // emit the labelled version of the event
-      signaller.apply(signaller, ['channel:closed:' + label].concat(args));
-
-      // decouple the events
-      channel.onopen = null;
+      channel.close();
     });
 
     // trigger stream:removed events for each of the remotestreams in the pc

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rtc-filter-grayscale": "~0.1.0",
     "rtc-media": "^1",
     "rtc-plugin-temasys": "^1.1.1",
-    "rtc-quickconnect-test": "^2.0.0",
+    "rtc-quickconnect-test": "^2.3.0",
     "rtc-switchboard": "^3.0.0",
     "rtc-videoproc": "^0.11.0",
     "tap-spec": "^3.0.0",


### PR DESCRIPTION
This prevents multiple data channels with the same name being open at the same time to a peer.

Take for example the following situation:

```
qc.createDataChannel('channel1');
qc.createDataChannel('channel1');
```

Currently, this would cause two data channels, both labeled `channel1` to be created to each call peer. However, the `qc.calls.channels` entry for each peer would only contain one channel (the last one, due to the second overriding the first entry), although the peer connection still has two.

With this PR, the second call two `qc.createDataChannel` would be a no-op, due to it detecting an open channel with the same label already existing.

This is important because of the following case regarding the creation of a data mesh infrastructure:

1. 3 peers join a call (A, B, and C)
2. A datachannel `mesh` is created on each peer connection.
3. At some point, the datachannel `mesh` between B and C fails.
4. Attempting to recover the mesh, an additional call to `qc.createDatachannel` is made.
5. A new datachannel is created for the peer connection between B and C. However, a new datachannel between A and B, and A and C is also created. This can cause problems now.

With the updates, a call to `qc.createDataChannel` can be made to ensure that a data channel with the given name exists for all connected peers.