### PR TITLE
Check the data channel state in the channel monitor

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,6 +149,7 @@ module.exports = function (signalhost, opts) {
   var expectedLocalStreams = parseInt((opts || {}).expectedLocalStreams, 10) || 0;
   var announceTimer = 0;
   var updateTimer = 0;
+  var CLOSED_STATES = ['failed', 'closed'];
 
   function checkReadyToAnnounce() {
     clearTimeout(announceTimer);
@@ -402,9 +403,10 @@ module.exports = function (signalhost, opts) {
       if (channel.readyState === 'open') {
         channelReady();
       }
-      // If the underlying connection has failed/closed, then terminate the monitor
-      else if (['failed', 'closed'].indexOf(pc.iceConnectionState) !== -1) {
-        debug('connection has terminated, cancelling channel monitor');
+      // If the underlying connection has failed/closed, or if the ready state of the channel has transitioned to a closure
+      // state, then terminate the monitor
+      else if (CLOSED_STATES.indexOf(pc.iceConnectionState) !== -1 || CLOSED_STATES.indexOf(channel.readyState) !== -1) {
+        debug('connection or channel has terminated, cancelling channel monitor');
         clearInterval(channelMonitor);
         clearTimeout(channelConnectionTimer);
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "grunt-browserify": "^3.4.0",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
+    "hosted-git-info": "2.5.0",
     "rtc-bufferedchannel": "^0.5.0",
     "rtc-captureconfig": "^2.1.0",
     "rtc-filter-grayscale": "~0.1.0",


### PR DESCRIPTION
This fixes a case whereby the channel monitor is stuck constantly running when the data channel has not been detected as being opened yet, but the channel has already been closed.