### PR TITLE
Allow schemes to allow/reject connections at connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,6 +204,13 @@ module.exports = function (signalhost, opts) {
     if (data.id !== id) {
       return debug('mismatching ids, expected: ' + id + ', got: ' + data.id);
     }
+
+    // Allow prevention of connections if required
+    if (scheme && typeof scheme.allowConnection === 'function' && !scheme.allowConnection(id, data)) {
+      signaller('peer:rejected', id, data, scheme);
+      return debug('peer connection was rejected for ' + id);
+    }
+
     pending[id] = Date.now();
 
     // end any call to this id so we know we are starting fresh


### PR DESCRIPTION
This adds supports for schemes to provide an `allowConnection` function that can will be called prior to the connection attempt being started that allows for acceptance/rejection of the connection based on application requirements.

This function should looks like:

```
allowConnection: (peerId, data) => {
  if (some_condition_for_connection_met) return true;
  // Otherwise reject connection
  return false;
}
```

If a connection is rejected, the `peer:rejected` event is emitted.