### PR TITLE
Prefer Unified plan in Edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
     - BROWSER=firefox BVER=beta
     - BROWSER=firefox BVER=unstable
 
+services:
+  - xvfb
+
 matrix:
   fast_finish: true
 
@@ -26,7 +29,6 @@ matrix:
 before_script:
   - ./node_modules/travis-multirunner/setup.sh
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true

--- a/lib/sdpsupport.js
+++ b/lib/sdpsupport.js
@@ -24,6 +24,9 @@ var BROWSER_SUPPORT = {
         '12.1.1.0': [UNIFIED_PLAN, PLAN_B],
         '12.0.0.0': [PLAN_B, UNIFIED_PLAN], // currently, worked one
         '11.0': [PLAN_B]
+    },
+    'edge-chromium': {
+        '79.0.0.0': [UNIFIED_PLAN, PLAN_B]
     }
 };
 var DEFAULT_SUPPORT = [DEFAULT_SEMANTIC];


### PR DESCRIPTION
At the moment, QuickConnect prefers Pland B over Unified plan in Edge browser. This leads to issues such as some media streams not being correctly detected in applications. This PR adds SDP preferences for Edge browser to fix this.